### PR TITLE
Improve STT model initialization

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,7 @@ soundfile>=0.12
 pyttsx3>=2.90
 torch>=2.0
 faster-whisper>=0.10
+openai-whisper>=20231111
+requests>=2.0
 vosk>=0.3.44
 webrtcvad>=2.0.10

--- a/speech_thread.py
+++ b/speech_thread.py
@@ -1,11 +1,18 @@
 import sys, os, json, queue, subprocess, tempfile, shutil, time, traceback
 import numpy as np, sounddevice as sd, soundfile as sf, pyttsx3, torch
+import zipfile, requests
+from urllib.parse import urlparse
+from pathlib import Path
 from PyQt5 import QtCore
 
 try:
     from faster_whisper import WhisperModel
 except Exception:
     WhisperModel = None
+try:
+    import whisper as openai_whisper
+except Exception:
+    openai_whisper = None
 try:
     from vosk import Model as VoskModel, KaldiRecognizer
 except Exception:
@@ -30,26 +37,93 @@ class SpeechThread(QtCore.QThread):
         self.running = True
         self.buffer = ''
         self.rate = 16000
-        self._init_stt()
+        self.mode = None
+        if not self.cfg.get('typing_only'):
+            self._init_stt()
         self._init_tts()
 
     def _init_stt(self):
-        stt = self.cfg['stt_engine']
-        model_path = self.cfg['model_path']
-        if stt == 'Whisper' and WhisperModel:
-            self.model = WhisperModel('base.en', compute_type='int8')
-            self.mode = 'whisper'
-        elif stt == 'Vosk' and VoskModel:
-            self.model = KaldiRecognizer(VoskModel(model_path), self.rate)
-            self.model.SetWords(False)
-            self.mode = 'vosk'
-        else:
-            m, dec, utils = torch.hub.load('snakers4/silero-models', 'silero_stt', language='en')
+        """
+        Initialize the chosen STT engine, with automatic path detection:
+          - WhisperModel: defaults to 'tiny.en' if no path given
+          - VoskModel: unzips .zip, descends into single-subfolder directories
+          - Silero: fallback if neither Whisper nor Vosk loads
+        """
+        stt = self.cfg.get('stt_engine', 'Whisper').lower()
+        model_p = self.cfg.get('model_path', '').strip()
+        if model_p.startswith(('http://', 'https://')):
+            try:
+                cache = Path(tempfile.gettempdir()) / 'stt_models'
+                cache.mkdir(exist_ok=True)
+                target = cache / os.path.basename(urlparse(model_p).path)
+                if not target.is_file():
+                    with requests.get(model_p, stream=True) as r:
+                        r.raise_for_status()
+                        with open(target, 'wb') as f:
+                            for chunk in r.iter_content(8192):
+                                f.write(chunk)
+                model_p = str(target)
+            except Exception as e:
+                print(f"[WARN] download failed: {e}")
+
+        # --- WHISPER (via faster-whisper, then openai-whisper) ---
+        if stt == 'whisper':
+            if WhisperModel:
+                try:
+                    model_name = model_p or 'tiny.en'
+                    self.model = WhisperModel(model_name, compute_type='int8')
+                    self.mode = 'whisper'
+                    return
+                except Exception as e:
+                    print(f"[WARN] faster-whisper failed: {e}")
+            if openai_whisper:
+                try:
+                    model_name = model_p or 'base'
+                    self.model = openai_whisper.load_model(model_name)
+                    self.mode = 'openai-whisper'
+                    return
+                except Exception as e:
+                    print(f"[WARN] openai-whisper failed: {e}")
+
+        # --- VOSK (local model directory or zip) ---
+        if stt == 'vosk' and VoskModel:
+            if model_p.lower().endswith('.zip') and os.path.isfile(model_p):
+                tmp = tempfile.mkdtemp(prefix='vosk_')
+                with zipfile.ZipFile(model_p, 'r') as z:
+                    z.extractall(tmp)
+                model_p = tmp
+
+            if os.path.isdir(model_p):
+                subs = [os.path.join(model_p, d) for d in os.listdir(model_p)
+                        if os.path.isdir(os.path.join(model_p, d))]
+                if len(subs) == 1:
+                    model_p = subs[0]
+
+            if os.path.isdir(model_p):
+                self.model = KaldiRecognizer(VoskModel(model_p), self.rate)
+                self.model.SetWords(False)
+                self.mode = 'vosk'
+                return
+            else:
+                print(f"[WARN] Vosk model not found at: {model_p}")
+
+        # --- SILERO (last-resort fallback) ---
+        try:
+            m, dec, utils = torch.hub.load(
+                'snakers4/silero-models',
+                'silero_stt',
+                language=self.cfg.get('silero_lang', 'en')
+            )
             m.to('cpu')
             self.model = m
             self.decoder = dec
             self.prepare = utils[-1]
             self.mode = 'silero'
+            return
+        except Exception as e:
+            print(f"[ERROR] Silero load failed: {e}")
+
+        raise RuntimeError("No valid STT engine could be initialized.")
 
     def _init_tts(self):
         self.sox_ok = shutil.which('sox') is not None


### PR DESCRIPTION
## Summary
- deduplicate and expand imports for model downloads
- allow `model_path` URLs and cache downloaded models
- fallback to OpenAI whisper if faster-whisper fails
- add `openai-whisper` and `requests` dependencies
- add typing-only mode checkbox to skip STT

## Testing
- `python -m py_compile speech_thread.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_68690da739e4832f989c9657e22c3cde